### PR TITLE
change env for gitlab instance url

### DIFF
--- a/src/notifier/gitlab.rs
+++ b/src/notifier/gitlab.rs
@@ -38,7 +38,7 @@ impl GitlabNotifier {
     }
 
     fn get_base_url() -> Result<String> {
-        Ok(env::var("CI_SERVER_URL")?)
+        Ok(env::var("CI_SERVER_HOST")?)
     }
 
     fn get_project() -> Result<u64> {


### PR DESCRIPTION
SSIA

[gitlab](https://docs.rs/gitlab/0.1505.0/gitlab/index.html) crate needs GitLab URL without protocol or port. For example `gitlab.example.com`, not `https://gitlab.example.com:8000`