### PR TITLE
support target and empty output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,20 @@ skaffold render -p dev | kubectl diff -f - 2> /dev/null | | ksnotify --notifier 
 ```
 
 The concrete example of GitLab CI configuration is shown in [example](https://github.com/hirosassa/ksnotify/tree/main/example).
+
+
+## For developers
+
+To run `ksnotify` locally, use local option for debug.
+For local mode, `ksnotify` just renders contents on stdout.
+
+```console
+skaffold render -p dev | kubectl diff -f - 2> /dev/null | ~/Dev/ksnotify/ksnotify --ci local --notifier gitlab --suppress-skaffold
+
+> ## Plan result
+> [CI link](  )
+>
+> * updated
+> blah
+> blah
+```

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -5,8 +5,13 @@ use strum_macros::EnumString;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, EnumString)]
 pub enum CIKind {
+    /// ksnotify is running on GitLab CI.
     #[strum(serialize = "gitlab")]
     GitLab,
+
+    /// ksnotify is running on Local PC (for debug).
+    #[strum(serialize = "local")]
+    Local,
 }
 
 #[derive(Clone, Debug)]
@@ -32,6 +37,10 @@ impl CI {
                     merge_request,
                 })
             }
+            CIKind::Local => Ok(Self {
+                job_url: "".to_string(),
+                merge_request: MergeRequest { number: 1 },
+            }),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,11 @@ pub struct Cli {
     #[arg(long)]
     pub notifier: Option<String>,
 
-    /// Whether if suppress diffs comes from Skaffold labels
+    /// Target component name to distinguish for each environments or product.
+    #[arg(long)]
+    pub target: Option<String>,
+
+    /// Whether if suppress diffs comes from Skaffold labels.
     #[arg(long)]
     pub suppress_skaffold: bool,
 
@@ -69,7 +73,8 @@ fn run() -> Result<()> {
     io::stdin().read_to_string(&mut body)?;
     let parser = parser::DiffParser::new(config.suppress_skaffold)?;
     let result = parser.parse(&body)?;
-    let template = template::Template::new(result.kind_result, ci.job_url().to_string());
+    let template =
+        template::Template::new(result.kind_result, ci.job_url().to_string(), cli.target);
 
     notifier
         .notify(template.render()?)

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,19 +7,24 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Template {
-    title: String,
+    target: Option<String>,
     changed_kinds: String,
     details: String,
     link: String,
+    is_no_changes: bool,
 }
 
 impl Template {
-    const DEFAULT_BUILD_TITLE: &'static str = "## Plan result";
-
-    const DEFAULT_BUILD_TEMPLATE: &'static str = "{{ title }}
-
+    const DEFAULT_BUILD_TITLE_TEMPLATE: &'static str =
+        "## Plan result{{#if target}} ({{target}}){{/if}}";
+    const DEFAULT_BUILD_BODY_TEMPLATE: &'static str = "
 [CI link]( {{ link }} )
 
+{{#if is_no_changes}}
+```
+No changes. Kubernetes configurations are up-to-date.
+```
+{{else}}
 * updated
 {{ changed_kinds }}
 
@@ -28,23 +33,28 @@ impl Template {
 {{{ details }}}
 
 </details>
+{{/if}}
 ";
 
-    pub fn new(results: HashMap<String, String>, link: String) -> Self {
+    pub fn new(results: HashMap<String, String>, link: String, target: Option<String>) -> Self {
         let changed_kinds = Self::generate_changed_kinds_markdown(&results);
         let details = Self::generate_details_markdown(&results);
+        let is_no_changes = results.is_empty();
         Self {
-            title: Self::DEFAULT_BUILD_TITLE.to_string(),
+            target,
             changed_kinds,
             details,
             link,
+            is_no_changes,
         }
     }
 
     pub fn render(&self) -> Result<String> {
         let reg = Handlebars::new();
         let j = serde_json::to_value(self).unwrap();
-        Ok(reg.render_template(Self::DEFAULT_BUILD_TEMPLATE, &j)?)
+        let title = reg.render_template(Self::DEFAULT_BUILD_TITLE_TEMPLATE, &j)?;
+        let body = reg.render_template(Self::DEFAULT_BUILD_BODY_TEMPLATE, &j)?;
+        Ok(format!("{}{}", title, body))
     }
 
     fn generate_changed_kinds_markdown(results: &HashMap<String, String>) -> String {
@@ -57,7 +67,7 @@ impl Template {
         let details: Vec<String> = kinds
             .iter()
             .map(|k| {
-                let title = format!("## {}", k);
+                let title = format!("### {}", k);
                 let body = format!("```diff\n{}\n```", results[k]);
                 format!("{}\n{}", title, body)
             })
@@ -94,7 +104,94 @@ mod tests {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
         let actual = Template::generate_details_markdown(&data);
-        let expected = "## test1\n```diff\nABC\n```\n## test2\n```diff\nDEF\n```".to_string();
+        let expected = "### test1\n```diff\nABC\n```\n### test2\n```diff\nDEF\n```".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_new_with_no_changes() {
+        let results: HashMap<String, String> = HashMap::new();
+        let link = "http://example.com".to_string();
+        let target = Some("sample app".to_string());
+        let t = Template::new(results, link, target);
+        assert_eq!(t.is_no_changes, true);
+    }
+
+    #[test]
+    fn test_new_with_some_changes() {
+        let mut results: HashMap<String, String> = HashMap::new();
+        results.insert("sample".to_string(), "change content".to_string());
+        let link = "http://example.com".to_string();
+        let target = Some("sample app".to_string());
+        let t = Template::new(results, link, target);
+        assert_eq!(t.is_no_changes, false);
+    }
+
+    #[test]
+    fn test_render_title_with_target() {
+        let reg = Handlebars::new();
+        let mut data = HashMap::new();
+        data.insert("target".to_string(), "sample".to_string());
+        let actual = reg
+            .render_template(Template::DEFAULT_BUILD_TITLE_TEMPLATE, &data)
+            .unwrap();
+        let expected = "## Plan result (sample)".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_render_title_without_target() {
+        let reg = Handlebars::new();
+        let data = HashMap::<String, String>::new();
+        let actual = reg
+            .render_template(Template::DEFAULT_BUILD_TITLE_TEMPLATE, &data)
+            .unwrap();
+        let expected = "## Plan result".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_render_body_with_no_changes() {
+        let reg = Handlebars::new();
+        let mut data = HashMap::new();
+        data.insert("is_no_changes".to_string(), "true".to_string());
+        data.insert("link".to_string(), "http://example.com".to_string());
+        let actual = reg
+            .render_template(Template::DEFAULT_BUILD_BODY_TEMPLATE, &data)
+            .unwrap();
+        let expected = "
+[CI link]( http://example.com )
+
+```
+No changes. Kubernetes configurations are up-to-date.
+```
+"
+        .to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_render_body_with_changes() {
+        let reg = Handlebars::new();
+        let mut data = HashMap::new();
+        data.insert("link".to_string(), "http://example.com".to_string());
+        data.insert("link".to_string(), "http://example.com".to_string());
+        let actual = reg
+            .render_template(Template::DEFAULT_BUILD_BODY_TEMPLATE, &data)
+            .unwrap();
+        let expected = "
+[CI link]( http://example.com )
+
+* updated
+
+
+<details><summary>Details (Click me)</summary>
+
+
+
+</details>
+"
+        .to_string();
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
In this PR, I implemented followings:

- `target` variable support which adds `target` variable on comment title.
- no changes output which display `no changes` explicitly.

If you run `ksnotify --target sample` then we get following output:

----

## Plan result (sample)

[CI link]( https://example.com )

* updated
  * apps.v1.Deployment.test.test-app

<details><summary>Details (Click me)</summary>

## apps.v1.Deployment.jasmine.test-app
```diff
 @@ -5,7 +5,6 @@
     deployment.kubernetes.io/revision: "3"
+  labels:
+    app: test-app
   name: test-app
   namespace: test
 spec:
@@ -27,7 +26,6 @@
       creationTimestamp: null
       labels:
         app: test-app
-        skaffold.dev/run-id: 1234
     spec:
       containers:
       - args:
```
</details>

----

If you run ksnotify without any change in k8s configuration then we get following output:

----

## Plan result (sample)

[CI link]( https://example.com )

```
No changes. Kubernetes configurations are up-to-date.
```
