### PR TITLE
allow to set multiple image names with delimiter for ignore_tag_images

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ pub struct Cli {
     pub config: Option<PathBuf>,
 
     /// Image names to ignore tag differences.
-    #[arg(long)]
+    #[arg(long, value_delimiter = ',')]
     pub ignore_tag_images: Vec<String>,
 
     #[clap(flatten)]


### PR DESCRIPTION
There are some cases that we want to set multiple values for image names.

How ever we can only set multiple image names in  following: 

```
--ignore-tag-images image_name_1 --ignore-tag-images image_name_2
```

It is much easier if we can set in following format, because writing format can be shared regardless of number of images.

```
--ignore-tag-images image_name_1,image_name_2
```