### PR TITLE
Remove Windows build target from release CI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,13 +3,12 @@ version: 2
 project_name: ksnotify
 
 builds:
-  - id: build-linux-windows
+  - id: build-linux
     skip: '{{ eq .Runtime.Goos "darwin" }}'
     builder: rust
     binary: ksnotify
     targets:
       - x86_64-unknown-linux-gnu
-      - x86_64-pc-windows-gnu
     tool: cargo
     command: zigbuild
     flags:
@@ -34,9 +33,6 @@ builds:
 
 archives:
   - formats: [ 'tar.gz' ]
-    format_overrides:
-      - goos: windows
-        formats: [ 'zip' ]
     name_template: >-
       {{ .ProjectName }}-
       {{- if eq .Arch "amd64" }}x86_64
@@ -44,7 +40,7 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}-
       {{- .Os }}
     ids:
-      - build-linux-windows
+      - build-linux
       - build-macos
     allow_different_binary_count: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1528,7 +1528,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1951,9 +1951,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
## Summary

- Remove x86_64-pc-windows-gnu from goreleaser build targets
- The Windows cross-compilation fails due to aws-lc-sys requiring sched.h, which is unavailable in the zigbuild cross-compilation environment
- This dependency is pulled in by reqwest's rustls feature (hardcoded to aws-lc-rs backend) and cannot be avoided from downstream
- ksnotify is a kubectl companion tool primarily used on Linux/macOS; Windows support is not needed