### PR TITLE
fix: install rustls CryptoProvider to prevent startup panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "log",
  "octocrab",
  "regex",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap-verbosity-flag = "3"
 log = "0.4"
 env_logger = "0.11.10"
 octocrab = "0.53.0"
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
 tokio = { version = "1.52.3", features = ["rt-multi-thread"] }
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,13 @@ pub struct Cli {
 }
 
 fn main() {
+    // rustls 0.23 pulls in both `aws-lc-rs` and `ring` crypto providers through our
+    // dependency tree, so it cannot pick a process-level default on its own and panics
+    // on the first TLS handshake. Install one explicitly before any HTTPS request.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls aws-lc-rs CryptoProvider");
+
     if let Err(err) = run() {
         error!("Error: {err:#?}");
         process::exit(1);


### PR DESCRIPTION
## Problem

Since v3.2.0, `ksnotify` panics on startup before it can post any diff, on the first TLS handshake to the GitHub/GitLab API:

```
thread 'main' panicked at rustls-0.23.37/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

The dependency tree now pulls in **both** rustls crypto backends — `aws-lc-rs` and `ring` are both listed under `rustls 0.23.37` in `Cargo.lock` (brought in via the `octocrab 0.53` / `gitlab 0.1900` bumps in v3.2.0). When more than one provider is compiled in, rustls 0.23 cannot select a process-level default on its own and panics the first time TLS is used.

This makes v3.2.0 unusable for the GitHub/GitLab notifiers (the Local path that does no HTTPS is unaffected).

## Fix

Install the `aws-lc-rs` provider explicitly at the very start of `main()`, before any network request:

```rust
rustls::crypto::aws_lc_rs::default_provider()
    .install_default()
    .expect("failed to install rustls aws-lc-rs CryptoProvider");
```

- `Cargo.toml`: add `rustls = { version = "0.23", features = ["aws_lc_rs"] }` (already in the tree transitively; the resolved version is unchanged).
- `Cargo.lock`: add `rustls` to the `ksnotify` package's direct dependencies (no version changes).

## Verification

Built natively (aarch64, rustc 1.96.0) replicating the CI checks:

- `cargo fmt --all -- --check` — pass
- `cargo check` — pass
- `cargo clippy -- -D warnings -W clippy::nursery` — pass (no warnings)