### PR TITLE
Fix get_repository() panic and add error-path test coverage

### DIFF
--- a/src/ci/notifier/github.rs
+++ b/src/ci/notifier/github.rs
@@ -72,8 +72,10 @@ impl GithubNotifier {
     fn get_repository() -> Result<(String, String)> {
         // GITHUB_REPOSITORY is like <owner>/<repo>
         let env = env::var("GITHUB_REPOSITORY").context("GITHUB_REPOSITORY must be set")?;
-        let parts = env.split('/').collect::<Vec<&str>>();
-        Ok((parts[0].to_string(), parts[1].to_string()))
+        let (owner, repo) = env
+            .split_once('/')
+            .context("GITHUB_REPOSITORY must be in <owner>/<repo> format")?;
+        Ok((owner.to_string(), repo.to_string()))
     }
 
     #[allow(clippy::collapsible_if)]
@@ -182,6 +184,20 @@ mod tests {
     }
 
     #[test]
+    fn test_get_repository_without_slash_returns_error() {
+        temp_env::with_var("GITHUB_REPOSITORY", Some("repo-without-owner"), || {
+            let result = GithubNotifier::get_repository();
+            assert!(result.is_err());
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("GITHUB_REPOSITORY must be in <owner>/<repo> format")
+            );
+        });
+    }
+
+    #[test]
     fn test_get_job_url() {
         temp_env::with_vars(
             [
@@ -221,6 +237,42 @@ mod tests {
                 let pull_request = GithubNotifier::get_pull_request().unwrap();
                 assert_eq!(pull_request.number, None);
                 assert_eq!(pull_request.commit_sha, "abc123");
+            },
+        );
+    }
+
+    #[test]
+    fn test_get_pull_request_with_non_numeric_number_returns_error() {
+        temp_env::with_vars(
+            [
+                ("GITHUB_REF_NAME", Some("not-a-number/merge")),
+                ("GITHUB_SHA", Some("abc123")),
+            ],
+            || {
+                let result = GithubNotifier::get_pull_request();
+                assert!(result.is_err());
+                // parse::<u64> failure is surfaced as an "invalid digit" ParseIntError
+                assert!(result.unwrap_err().to_string().contains("invalid digit"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_get_pull_request_missing_sha_returns_error() {
+        temp_env::with_vars(
+            [
+                ("GITHUB_REF_NAME", Some("123/merge")),
+                ("GITHUB_SHA", None::<&str>),
+            ],
+            || {
+                let result = GithubNotifier::get_pull_request();
+                assert!(result.is_err());
+                assert!(
+                    result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("GITHUB_SHA must be set")
+                );
             },
         );
     }

--- a/src/ci/notifier/gitlab.rs
+++ b/src/ci/notifier/gitlab.rs
@@ -220,6 +220,35 @@ mod tests {
     }
 
     #[test]
+    fn test_get_merge_request_with_non_numeric_iid_returns_error() {
+        temp_env::with_vars(
+            [
+                ("CI_MERGE_REQUEST_IID", Some("not-a-number")),
+                ("CI_COMMIT_SHA", Some("abcdefg")),
+            ],
+            || {
+                let result = GitlabNotifier::get_merge_request();
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("invalid digit"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_get_merge_request_missing_commit_sha_returns_error() {
+        temp_env::with_vars(
+            [
+                ("CI_MERGE_REQUEST_IID", Some("123")),
+                ("CI_COMMIT_SHA", None::<&str>),
+            ],
+            || {
+                let result = GitlabNotifier::get_merge_request();
+                assert!(result.is_err());
+            },
+        );
+    }
+
+    #[test]
     fn test_get_base_url() {
         temp_env::with_var("CI_SERVER_HOST", Some("gitlab.example.com"), || {
             let base_url = GitlabNotifier::get_base_url().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,34 @@ patch: false
     }
 
     #[test]
+    fn test_new_from_env_suppress_argocd_is_independent_of_skaffold() {
+        // Set only SUPPRESS_ARGOCD to ensure the two flags are not swapped or conflated.
+        temp_env::with_vars(
+            [
+                ("KSNOTIFY_CI", Some("github")),
+                ("KSNOTIFY_SUPPRESS_ARGOCD", Some("true")),
+                ("KSNOTIFY_SUPPRESS_SKAFFOLD", None::<&str>),
+            ],
+            || {
+                let config = Config::new(&Cli {
+                    ci: None,
+                    target: None,
+                    suppress_skaffold: false,
+                    suppress_argocd: false,
+                    ignore_tag_images: vec![],
+                    patch: false,
+                    config: None,
+                    verbose: Verbosity::<ErrorLevel>::default(),
+                })
+                .unwrap();
+
+                assert!(config.suppress_argocd);
+                assert!(!config.suppress_skaffold);
+            },
+        );
+    }
+
+    #[test]
     fn test_new_from_env_without_ignore_tag_images() {
         temp_env::with_vars(
             [
@@ -213,6 +241,59 @@ patch: false
                 assert!(config.ignore_tag_images.is_empty());
             },
         );
+    }
+
+    #[test]
+    fn test_new_with_invalid_ci_arg_returns_error() {
+        let result = Config::new(&Cli {
+            ci: Some("invalid-ci".to_string()),
+            target: None,
+            suppress_skaffold: false,
+            suppress_argocd: false,
+            ignore_tag_images: vec![],
+            patch: false,
+            config: None,
+            verbose: Verbosity::<ErrorLevel>::default(),
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_file_missing_file_returns_error() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let missing_path = temp_dir.path().join("does-not-exist.yaml");
+
+        let result = Config::new(&Cli {
+            ci: None,
+            target: None,
+            suppress_skaffold: false,
+            suppress_argocd: false,
+            ignore_tag_images: vec![],
+            patch: false,
+            config: Some(missing_path),
+            verbose: Verbosity::<ErrorLevel>::default(),
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_file_invalid_yaml_returns_error() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.yaml");
+        // valid YAML syntax but missing required fields / wrong shape for Config
+        fs::write(&config_path, "not: a valid config\n").unwrap();
+
+        let result = Config::new(&Cli {
+            ci: None,
+            target: None,
+            suppress_skaffold: false,
+            suppress_argocd: false,
+            ignore_tag_images: vec![],
+            patch: false,
+            config: Some(config_path),
+            verbose: Verbosity::<ErrorLevel>::default(),
+        });
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Coverage analysis surfaced untested error paths in the CI notifiers and
config loader. While adding tests, found and fixed a real panic bug.

## Changes

- Fix panic in `get_repository()`: `GITHUB_REPOSITORY` without a `/` caused an index-out-of-bounds panic. Now returns an `Err` via `split_once`.
- GitHub notifier tests: malformed repo, non-numeric PR number, missing `GITHUB_SHA`.
- GitLab notifier tests: non-numeric `CI_MERGE_REQUEST_IID`, missing `CI_COMMIT_SHA`.
- Config tests: invalid `--ci` arg, missing config file, invalid YAML, and `suppress_argocd` set independently of `suppress_skaffold`.